### PR TITLE
[FIX Jenkins-49053] handled Case when changelogFile is null

### DIFF
--- a/src/main/java/hudson/plugins/filesystem_scm/FSSCM.java
+++ b/src/main/java/hudson/plugins/filesystem_scm/FSSCM.java
@@ -11,6 +11,7 @@ import hudson.Launcher;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.plugins.filesystem_scm.ChangelogSet.XMLSerializer;
 import hudson.scm.ChangeLogParser;
 import hudson.scm.PollingResult;
 import hudson.scm.SCMRevisionState;
@@ -208,16 +209,28 @@ public class FSSCM extends SCM {
 		String str = callable.getLog();
 		if ( str.length() > 0 ) log.println(str);
 		
-		ChangelogSet.XMLSerializer handler = new ChangelogSet.XMLSerializer();
-		ChangelogSet changeLogSet = new ChangelogSet(build, list);
-		handler.save(changeLogSet, changelogFile);
+		processChangelog(build, changelogFile, list);
 		
 		log.println("FSSCM.check completed in " + formatDuration(System.currentTimeMillis()-start));
+	}
+
+	protected void processChangelog(Run<?, ?> build, File changelogFile, List<FolderDiff.Entry> list)
+			throws FileNotFoundException {
+		// checking for null as the @CheckForNull Annotation @asks for by SCM.checkout 
+		if(changelogFile!=null) {
+			ChangelogSet.XMLSerializer serializer = createXMLSerializer();
+			ChangelogSet changeLogSet = new ChangelogSet(build, list);
+			serializer.save(changeLogSet, changelogFile);
+		}
+	}
+
+	private XMLSerializer createXMLSerializer() {
+		return new ChangelogSet.XMLSerializer();
 	}
 	
 	@Override
 	public ChangeLogParser createChangeLogParser() {
-		return new ChangelogSet.XMLSerializer();
+		return createXMLSerializer();
 	}
 
 	/**

--- a/src/test/java/hudson/plugins/filesystem_scm/FSSCMTest.java
+++ b/src/test/java/hudson/plugins/filesystem_scm/FSSCMTest.java
@@ -1,0 +1,35 @@
+package hudson.plugins.filesystem_scm;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import hudson.plugins.filesystem_scm.FolderDiff.Entry;
+
+public class FSSCMTest {
+	
+	@Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+	
+	FSSCM fsscm = new FSSCM("", false, false, null);
+	List<Entry> list = new ArrayList<>();
+	
+	@Test
+	public void processChangelog_nullChangelogFile_NoException() throws FileNotFoundException {
+		fsscm.processChangelog(null, null, list);
+	}
+	
+	@Test
+	public void processChangelog_ChangelogFile_createdChanelogFile() throws FileNotFoundException {
+		File changeLogFile = new File(testFolder.getRoot(),"changelog.xml");
+		Assert.assertFalse(changeLogFile.exists());
+		fsscm.processChangelog(null, changeLogFile, list);
+		Assert.assertTrue(changeLogFile.exists());
+	}
+}


### PR DESCRIPTION
adjusted to comments of @oleg-nenashev 

why
- when the option is used, that the changelog of the FILESCM shall not be visible in the changelog of the build, then a null pointer occured when writing the changelog, because the changelogFile given to FileSCM had been null

what
- added tests and a fix for this situation