### PR TITLE
Ensure that the `copyHidden` setting is persisted and retained after the Jenkins service restart

### DIFF
--- a/src/main/java/hudson/plugins/filesystem_scm/FSSCM.java
+++ b/src/main/java/hudson/plugins/filesystem_scm/FSSCM.java
@@ -56,7 +56,7 @@ public class FSSCM extends SCM {
      * 
      */
 
-    private transient boolean copyHidden;
+    private boolean copyHidden;
     /**
      * If we have include/exclude filter, then this is true.
      *


### PR DESCRIPTION
Persist copyHidden in job's config.xml