### PR TITLE
[JENKINS-72067] Maintain just one `XStream2` for changelog parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+work

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,15 @@
 target
+
+# mvn hpi:run
 work
+
+# IntelliJ IDEA project files
+*.iml
+*.iws
+*.ipr
+.idea
+
+# Eclipse project files
+.settings
+.classpath
+.project

--- a/src/main/java/hudson/plugins/filesystem_scm/ChangelogSet.java
+++ b/src/main/java/hudson/plugins/filesystem_scm/ChangelogSet.java
@@ -88,18 +88,8 @@ public class ChangelogSet extends hudson.scm.ChangeLogSet<Changelog> {
     }
 
     public static class XMLSerializer extends hudson.scm.ChangeLogParser {
-        private transient XStream2 xstream;
-
-        private Object readResolve() { // xstream field used to be serialized in build.xml
-            initXStream();
-            return this;
-        }
-
-        public XMLSerializer() {
-            initXStream();
-        }
-
-        private void initXStream() {
+        private static final XStream2 xstream;
+        static {
             xstream = new XStream2();
             xstream.alias("log", ChangelogSet.class);
             // xstream.addImplicitCollection(ChangelogSet.class, "changeLogSet");


### PR DESCRIPTION
Complementing https://github.com/jenkinsci/jenkins/pull/8529. Untested; the parent POM here is so old I am unable to even compile the plugin.

Regardless of core version, this change seems desirable since constructing an `XStream` instance and warming up its converters is [potentially expensive](https://x-stream.github.io/faq.html#Scalability_Thread_safety).