### PR TITLE
fix: missing deprecated annotation

### DIFF
--- a/src/main/java/hudson/plugins/filesystem_scm/FSSCM.java
+++ b/src/main/java/hudson/plugins/filesystem_scm/FSSCM.java
@@ -128,6 +128,7 @@ public class FSSCM extends SCM {
      * @return an array of wildcards, or null
      * @deprecated Use {@link #getFilterSettings()}.
      */
+    @Deprecated
     @CheckForNull
     public String[] getFilters() {
         if (filterSettings == null) {


### PR DESCRIPTION
Fix Java warning by adding the missing `@Deprecated` annotation
 
### Testing done

Manually with `mvn hpi:run` 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
