### PR TITLE
Fix JENKINS-76145: Add verbose logging checkbox to make filesystem SCM logging configurable

### DIFF
--- a/src/main/java/hudson/plugins/filesystem_scm/FSSCM.java
+++ b/src/main/java/hudson/plugins/filesystem_scm/FSSCM.java
@@ -53,7 +53,7 @@ public class FSSCM extends SCM {
     private boolean clearWorkspace;
 
     /**
-     * If true, it will log all the file names along with their entry types. Default is true (for backwards compatibility).
+     * If true, it will log all the file names along with their entry types. Default is true (for backward compatibility).
      *
      */
     private boolean verboseLogging = true;
@@ -247,7 +247,7 @@ public class FSSCM extends SCM {
         if (str.length() > 0)
             log.println(str);
 
-        logSummary(log, list);
+        printLogSummary(log, callable.getNewCount(), callable.getModifiedCount(), callable.getDeletedCount());
 
         processChangelog(build, changelogFile, list);
 
@@ -268,20 +268,12 @@ public class FSSCM extends SCM {
      * Logs the count of files checked out.
      *
      */
-    private void logSummary(PrintStream log, List<FolderDiff.Entry> entries) {
-        int newCount = 0, modifiedCount = 0, deletedCount = 0;
+    private void printLogSummary(PrintStream log, int newCount, int modifiedCount, int deletedCount) {
+        int total = newCount + modifiedCount + deletedCount;
 
-        for (FolderDiff.Entry entry : entries) {
-            switch (entry.getType()) {
-                case NEW -> newCount++;
-                case MODIFIED -> modifiedCount++;
-                case DELETED -> deletedCount++;
-            }
-        }
-
-        if (!entries.isEmpty()) {
+        if (total > 0) {
             log.printf("Processed %d files (%d new, %d modified, %d deleted)%n",
-                    entries.size(), newCount, modifiedCount, deletedCount);
+                    total, newCount, modifiedCount, deletedCount);
         }
     }
 

--- a/src/main/java/hudson/plugins/filesystem_scm/FSSCM.java
+++ b/src/main/java/hudson/plugins/filesystem_scm/FSSCM.java
@@ -53,7 +53,7 @@ public class FSSCM extends SCM {
     private boolean clearWorkspace;
 
     /**
-     * If true, will log all the file names along with their entry types. Default is true (for backwards compatibility).
+     * If true, it will log all the file names along with their entry types. Default is true (for backwards compatibility).
      *
      */
     private boolean verboseLogging = true;

--- a/src/main/java/hudson/plugins/filesystem_scm/FolderDiff.java
+++ b/src/main/java/hudson/plugins/filesystem_scm/FolderDiff.java
@@ -21,7 +21,6 @@ import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.NotFileFilter;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.plugins.filesystem_scm.FolderDiff.Entry.Type;
 import hudson.remoting.VirtualChannel;
 import jenkins.MasterToSlaveFileCallable;
@@ -58,6 +57,10 @@ public class FolderDiff<T> extends MasterToSlaveFileCallable<T> implements Seria
     private String[] filters;
     private Set<String> allowDeleteList;
 
+    private int newCount = 0;
+    private int modifiedCount = 0;
+    private int deletedCount = 0;
+
     public FolderDiff() {
         filterEnabled = false;
     }
@@ -89,6 +92,10 @@ public class FolderDiff<T> extends MasterToSlaveFileCallable<T> implements Seria
     public void setAllowDeleteList(Set<String> allowDeleteList) {
         this.allowDeleteList = allowDeleteList;
     }
+
+    public int getNewCount() { return newCount; }
+    public int getModifiedCount() { return modifiedCount; }
+    public int getDeletedCount() { return deletedCount; }
 
     /**
      *
@@ -175,7 +182,12 @@ public class FolderDiff<T> extends MasterToSlaveFileCallable<T> implements Seria
         return list;
     }
 
-    private Entry createAndLogg(String relativeName, Type type) {
+    protected Entry createAndLogg(String relativeName, Type type) {
+        switch (type) {
+            case NEW -> newCount++;
+            case MODIFIED -> modifiedCount++;
+            case DELETED -> deletedCount++;
+        }
         log(type.name() + " file: " + relativeName);
         return new Entry(relativeName, type);
     }

--- a/src/main/java/hudson/plugins/filesystem_scm/RemoteFolderDiff.java
+++ b/src/main/java/hudson/plugins/filesystem_scm/RemoteFolderDiff.java
@@ -16,6 +16,7 @@ public class RemoteFolderDiff<T> extends FolderDiff<T> {
     protected StringBuffer buf;
     protected long lastBuildTime;
     protected long lastSuccessfulBuildTime;
+    protected boolean verboseLogging = true;
 
     public RemoteFolderDiff() {
         buf = new StringBuffer();
@@ -33,13 +34,18 @@ public class RemoteFolderDiff<T> extends FolderDiff<T> {
         return lastSuccessfulBuildTime;
     }
 
+    public void setVerboseLogging(boolean verboseLogging) {
+        this.verboseLogging = verboseLogging;
+    }
+
     public void setLastSuccessfulBuildTime(long lastSuccessfulBuildTime) {
         this.lastSuccessfulBuildTime = lastSuccessfulBuildTime;
     }
 
     @Override
     protected void log(String msg) {
-        buf.append(msg).append("\n");
+        if (verboseLogging)
+            buf.append(msg).append("\n");
     }
 
     @Override

--- a/src/main/resources/hudson/plugins/filesystem_scm/FSSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/filesystem_scm/FSSCM/config.jelly
@@ -9,5 +9,8 @@
   <f:entry title="Copy Hidden Files/Folders" field="copyHidden">
     <f:checkbox/>
   </f:entry>
+  <f:entry title="Verbose Logging" field="verboseLogging">
+    <f:checkbox default="true"/>
+  </f:entry>
   <f:optionalProperty title="Enable filtering" field="filterSettings"/>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/filesystem_scm/FSSCM/help-verboseLogging.html
+++ b/src/main/resources/hudson/plugins/filesystem_scm/FSSCM/help-verboseLogging.html
@@ -1,0 +1,12 @@
+<div>
+  <p>
+    Controls the verbosity of file operation logging during checkout.
+  </p>
+  <ul>
+    <li><strong>Checked (default):</strong> Shows detailed logs for each file operation (NEW file: filename.txt, MODIFIED file: filename.txt, etc.) plus a summary.</li>
+    <li><strong>Unchecked:</strong> Shows only a concise summary of processed files (e.g., "Processed 15 files (12 new, 2 modified, 1 deleted)").</li>
+  </ul>
+  <p>
+    For builds processing many files, unchecking this option makes build logs much more readable.
+  </p>
+</div>

--- a/src/test/java/hudson/plugins/filesystem_scm/FSSCMTest.java
+++ b/src/test/java/hudson/plugins/filesystem_scm/FSSCMTest.java
@@ -17,7 +17,7 @@ public class FSSCMTest {
 	@Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 	
-	FSSCM fsscm = new FSSCM("", false, false, null);
+	FSSCM fsscm = new FSSCM("", false, false, true, null);
 	List<Entry> list = new ArrayList<>();
 	
 	@Test

--- a/src/test/java/hudson/plugins/filesystem_scm/FSSCMTest.java
+++ b/src/test/java/hudson/plugins/filesystem_scm/FSSCMTest.java
@@ -32,4 +32,13 @@ class FSSCMTest {
         fsscm.processChangelog(null, changeLogFile, list);
         assertTrue(changeLogFile.exists());
     }
+
+    @Test
+    void verboseLogging_GetterSetter_WorkCorrectly() {
+        // Default value should be true
+        assertTrue(fsscm.isVerboseLogging());
+
+        fsscm.setVerboseLogging(false);
+        assertFalse(fsscm.isVerboseLogging()); // Should be false after setting.
+    }
 }

--- a/src/test/java/hudson/plugins/filesystem_scm/FolderDiffTest.java
+++ b/src/test/java/hudson/plugins/filesystem_scm/FolderDiffTest.java
@@ -156,6 +156,39 @@ class FolderDiffTest {
         assertMarkAsNewOrModified(new HashSet<>(), actualResult, diff);
     }
 
+    @Test
+    void createAndLogg_CountsEntriesCorrectly() {
+        FolderDiffFake<File> diff = getFolderDiff(src, dst);
+
+        // Test NEW files counting
+        FolderDiff.Entry newEntry = diff.createAndLogg("newFile.txt", FolderDiff.Entry.Type.NEW);
+        assertEquals(1, diff.getNewCount());
+        assertEquals(0, diff.getModifiedCount());
+        assertEquals(0, diff.getDeletedCount());
+        assertEquals("newFile.txt", newEntry.getFilename());
+        assertEquals(FolderDiff.Entry.Type.NEW, newEntry.getType());
+
+        // Test MODIFIED files counting
+        FolderDiff.Entry modifiedEntry = diff.createAndLogg("modifiedFile.txt", FolderDiff.Entry.Type.MODIFIED);
+        assertEquals(1, diff.getNewCount());
+        assertEquals(1, diff.getModifiedCount());
+        assertEquals(0, diff.getDeletedCount());
+
+        // Testing DELETED files counting
+        FolderDiff.Entry deletedEntry = diff.createAndLogg("deletedFile.txt", FolderDiff.Entry.Type.DELETED);
+        assertEquals(1, diff.getNewCount());
+        assertEquals(1, diff.getModifiedCount());
+        assertEquals(1, diff.getDeletedCount());
+
+        // Testing multiple operations
+        diff.createAndLogg("anotherNew.txt", FolderDiff.Entry.Type.NEW);
+        diff.createAndLogg("anotherModified.txt", FolderDiff.Entry.Type.MODIFIED);
+
+        assertEquals(2, diff.getNewCount());
+        assertEquals(2, diff.getModifiedCount());
+        assertEquals(1, diff.getDeletedCount());
+    }
+
     private void hideFile(String hiddenFilePathString) throws IOException {
         File hiddenFile = new File(src, hiddenFilePathString);
         // Windows specific code

--- a/src/test/java/hudson/plugins/filesystem_scm/integration/pipeline/PipelineLibraryTest.java
+++ b/src/test/java/hudson/plugins/filesystem_scm/integration/pipeline/PipelineLibraryTest.java
@@ -39,7 +39,7 @@ public class PipelineLibraryTest {
 
         // Create job
         WorkflowJob job = new WorkflowJob(j.jenkins, "MyPipeline");
-        job.setDefinition(new CpsScmFlowDefinition(new FSSCM(null, false, false,
+        job.setDefinition(new CpsScmFlowDefinition(new FSSCM(null, false, false, true,
                 new FilterSettings(true, Collections.<FilterSelector>emptyList())), "Jenkinsfile"));
 
         j.buildAndAssertSuccess(job);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## Fixes JENKINS-76145: Make filesystem SCM checkout logging configurable

### Problem
The File System SCM plugin currently logs every individual file operation (NEW file: x.txt, MODIFIED file: y.txt, etc.) during checkout, which creates excessive log spam for projects with many files. This makes build logs difficult to read and can overwhelm Jenkins console output for builds processing large libraries as reported in [JENKINS-76145](https://issues.jenkins.io/browse/JENKINS-76145).

### Solution
This PR adds a new "Verbose Logging" checkbox to the File System SCM job configuration that allows users to control logging verbosity:

- **Checked (default):** Shows list of file operations + summary (backward compatible behavior)
- **Unchecked:** Shows only a concise summary (e.g., "Processed 15 files (12 new, 2 modified, 1 deleted)")

### Implementation Details
- Added `verboseLogging` boolean field to `FSSCM` class with getter/setter
- Updated `RemoteFolderDiff.log()` method to conditionally append messages based on verbose flag
- Added `logSummary()` method to always show file counts regardless of verbose setting
- Updated Jelly UI template with new checkbox and help documentation

### Testing Done
- Manually tested both verbose logging ON and OFF modes
- Verified UI checkbox integration works correctly with help tooltip
- Confirmed backward compatibility - existing jobs continue to work with verbose=true default
- Build successful with `mvn clean package`
- Tested on Windows development setup with `mvn hpi:run`
- Created test directories with multiple files and verified log output differences
- Confirmed empty file lists produce no summary output (correct behavior)

### Screenshots

**Verbose logging checkbox:**

<img width="1349" height="629" alt="Screenshot 2025-09-27 171349" src="https://github.com/user-attachments/assets/a747e2cd-fa70-4c9d-aefb-8fd52ccfc84e" />

**Verbose ON:**

<img width="989" height="413" alt="Screenshot 2025-09-27 171937" src="https://github.com/user-attachments/assets/459d63b1-d7eb-4452-9d5f-009f7caced76" />

**Verbose OFF:**

<img width="1000" height="289" alt="Screenshot 2025-09-27 171523" src="https://github.com/user-attachments/assets/d6c905eb-fa06-47dd-b462-667543419ff3" />

### Note for reviewers:
This is my first open-source contribution at Jenkins and in general. I am a second year computer science student eager to learn more from the community. Feedbacks are very welcomed on any jenkins specific practices I may have missed. Looking forward to contribute more to Jenkins!

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
